### PR TITLE
Don't fail the script on expected alr test exit code

### DIFF
--- a/test-script.sh
+++ b/test-script.sh
@@ -22,7 +22,8 @@ testdir=alrtest
 # Check crates
 mkdir $testdir
 pushd $testdir
-alr -n test --newest --full
+alr -n test --newest --full || true
+# alr will exit with error if some crate didn't test out properly
 popd
 
 # Generate .md result file


### PR DESCRIPTION
We don't want to report CI failure even when `alr test` fails on a particular crate; the crate will show as errored and we'll be aware of it.