### PR TITLE
Update setup-alire to v5

### DIFF
--- a/.github/workflows/continuous-alire.yml
+++ b/.github/workflows/continuous-alire.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up stable `alr`
-      uses: alire-project/setup-alire@v4
+      uses: alire-project/setup-alire@v5
       with:
         toolchain: gnat_native${{ matrix.gnat_version }} gprbuild
 

--- a/.github/workflows/continuous-distros.yml
+++ b/.github/workflows/continuous-distros.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up stable `alr`
-      uses: alire-project/setup-alire@v4
+      uses: alire-project/setup-alire@v5
       with:
         toolchain: --disable-assistant
         # We want to use the externally provided toolchain in the docker image


### PR DESCRIPTION
v5 uses alr 2.1.0 by default, which should fix #16. I'm not able to test this locally, so please review/check if there's anything else that needs updating that I've missed.